### PR TITLE
オーディオファイル出力中停止した際の挙動変更

### DIFF
--- a/src/flmml-on-html5.ts
+++ b/src/flmml-on-html5.ts
@@ -154,9 +154,7 @@ export class FlMML {
                 break;
             case MsgTypes.EXPORT:
                 if (data.data) {
-                    this.audioExportResolve(data.data);
-                    this.audioExportResolve = null;
-                    this.audioExportReject = null;
+                    this.completeAudioExport(data.data);
                 } else {
                     this.errorAudioExport(data.errorMsg);
                 }
@@ -252,6 +250,13 @@ export class FlMML {
         });
     }
 
+    private completeAudioExport(data: ArrayBuffer[]): void {
+        if (!this.audioExportResolve) return;
+        this.audioExportResolve(data);
+        this.audioExportResolve = null;
+        this.audioExportReject = null;
+    }
+
     private errorAudioExport(msg: string): void {
         if (!this.audioExportReject) return;
         this.audioExportReject(new FlMMLAudioExportError(msg));
@@ -266,16 +271,10 @@ export class FlMML {
 
         if (!this.booted) this.boot();
         this.worker.postMessage({ type: MsgTypes.PLAY, mml: mml });
-        if (this.audioExportResolve) {
-            this.errorAudioExport("Aborted exporting audio file");
-        }
     }
 
     stop() {
         this.worker.postMessage({ type: MsgTypes.STOP });
-        if (this.audioExportResolve) {
-            this.errorAudioExport("Aborted exporting audio file");
-        }
     }
 
     pause() {

--- a/src/flmml-on-html5.worker.ts
+++ b/src/flmml-on-html5.worker.ts
@@ -40,11 +40,12 @@ export class FlMMLWorker {
             case MsgTypes.PLAY:
                 if (!mml) break;
                 mml.play(data.mml);
-                this.audioExport = null;
+                if (this.audioExport) this.completeAudioExport();
                 break;
             case MsgTypes.STOP:
                 mml && mml.stop();
                 this.syncInfo();
+                if (this.audioExport) this.completeAudioExport();
                 break;
             case MsgTypes.PAUSE:
                 mml && mml.pause();
@@ -94,6 +95,12 @@ export class FlMMLWorker {
         }
     }
 
+    private completeAudioExport(): void {
+        const data = this.audioExport.complete();
+        postMessage({ type: MsgTypes.EXPORT, data: data }, data);
+        this.audioExport = null;
+    }
+
     buffering(progress: number): void {
         postMessage({ type: MsgTypes.BUFRING, progress: progress });
     }
@@ -140,10 +147,7 @@ export class FlMMLWorker {
     complete(): void {
         postMessage({ type: MsgTypes.COMPLETE });
         this.syncInfo();
-        if (this.audioExport) {
-            const data = this.audioExport.complete();
-            postMessage({ type: MsgTypes.EXPORT, data: data }, data);
-        }
+        if (this.audioExport) this.completeAudioExport();
     }
 
     syncInfo(): void {


### PR DESCRIPTION
https://github.com/argentum384/flmml-on-html5/issues/42#issuecomment-913775961
> オーディオ出力処理中に停止した場合に reject して例外を投げてしまうのはやり過ぎだし、途中まで処理した分を出力するのはそう難しくないので、処理中に停止した場合は途中までの分を出力して処理完了とする。