### PR TITLE
付点音符が非整数ticksになりうる問題の修正

### DIFF
--- a/src/flmml/MML.ts
+++ b/src/flmml/MML.ts
@@ -652,7 +652,7 @@ export class MML {
         var intick: number = tick;
         while (c === '.') {
             this.next();
-            intick /= 2;
+            intick = Math.floor(intick / 2);
             tick += intick;
             c = this.getChar();
         }


### PR DESCRIPTION
Flash版では `c384.` のように付点を付けると非整数ticksになる音長指定はticks値の小数点以下が切り捨てられていたが、本HTML版では切り捨てられず、実際の発音時間も非整数ticks相当になっており差異がある。  
Flash版と同様の挙動になるよう修正する。