### PR TITLE
モジュールFM切り替え直後の440Hzのノートが極めて低くなる事象の対応

### DIFF
--- a/src/flmml/MOscOPM.ts
+++ b/src/flmml/MOscOPM.ts
@@ -93,6 +93,9 @@ export class MOscOPM extends MOscMod {
 
     constructor() {
         super();
+        // 最初のノート周波数が440Hzの場合にKCKF書き込みが働くよう上書き
+        this.m_frequency = 0;
+
         MOscOPM.boot();
         this.m_fm.Init(MOscOPM.OPM_CLOCK, SAMPLE_RATE);
         this.m_fm.Reset();


### PR DESCRIPTION
- #53 

の修正

### 原因
全音色共通でオシレータ周波数の初期値に
https://github.com/argentum384/flmml-on-html5/blob/9c9f568592bca1f9a5002ec87130e4dfcb4d8122/src/flmml/MOscMod.ts#L16
の通り440Hzが与えられているが、モジュールFMのみ周波数指定時
https://github.com/argentum384/flmml-on-html5/blob/9c9f568592bca1f9a5002ec87130e4dfcb4d8122/src/flmml/MOscOPM.ts#L304-L307
の通り周波数に変更がなければ fmgen のレジスタ書き込み処理を行わないようになっていたため。

### 対処
FMモジュールのオシレータのみ初期化後に周波数を0Hzで上書きし、最初のノートの周波数にかかわらず fmgen のレジスタ書き込みが行われるように修正

※早期 return をなくすのは同音連打時などにも不必要な書き込みが発生し挙動が変わってしまうので不採用