### PR TITLE
再生またはオーディオファイル出力が稀に停止してしまうことがある問題の修正

### DIFF
--- a/src/flmml/MSequencer.ts
+++ b/src/flmml/MSequencer.ts
@@ -245,6 +245,10 @@ export class MSequencer {
                 this.m_playSize = 0;
                 this.processStart();
             }
+            // バッファ完成後処理待ちの場合
+            else if (this.m_step === /*MSequencer.STEP_POST*/3) {
+                return;
+            }
             // バッファが未完成の場合
             else {
                 this.reqBuffering();


### PR DESCRIPTION
* #57 

の対応

---

https://github.com/argentum384/flmml-on-html5/blob/d707042dd5627b57c526db63ec41e7c9018dcb88/src/flmml/MSequencer.ts#L241 の分岐進入時に `this.m_step` が 3 (=`MSequencer.STEP_POST` ) だとバッファを作り終えているのにバッファリング状態になり、以降ずっとバッファの返却がスタックするようになっていた。

対処として↑の状況の場合早期 return してバッファリング状態になるのを回避する。  
(次の `onSampleData` 呼び出し時には `this.m_step` が 4 (=`MSequencer.STEP_COMPLETE` ) になっているはずなので既存の分岐に戻る)